### PR TITLE
Breakdown 'QuizDelegate' into Delegate and Data Source

### DIFF
--- a/App/QuizApp/AppDelegate.swift
+++ b/App/QuizApp/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
         
-        quiz = Quiz.start(questions: questions, delegate: router)
+        quiz = Quiz.start(questions: questions, delegate: router, dataSource: router)
         
         return true
     }

--- a/App/QuizApp/Routing/NavigationControllerRouter.swift
+++ b/App/QuizApp/Routing/NavigationControllerRouter.swift
@@ -5,7 +5,7 @@
 import UIKit
 import QuizEngine
 
-final class NavigationControllerRouter: QuizDelegate {
+final class NavigationControllerRouter: QuizDelegate, QuizDataSource {
     private let navigationController: UINavigationController
     private let factory: ViewControllerFactory
     

--- a/Engine/QuizEngine.xcodeproj/project.pbxproj
+++ b/Engine/QuizEngine.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		08CB6D991E67295C003D96A9 /* DeprecatedGameTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB6D501E671581003D96A9 /* DeprecatedGameTest.swift */; };
 		08CB6D9B1E67296A003D96A9 /* Flow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086816551E572137009359E4 /* Flow.swift */; };
 		08CB6D9E1E67296A003D96A9 /* DeprecatedGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB6D521E6716B3003D96A9 /* DeprecatedGame.swift */; };
+		8F23AB6824D6222A001E3465 /* QuizDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F23AB6724D6222A001E3465 /* QuizDataSource.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +66,7 @@
 		08CB6D521E6716B3003D96A9 /* DeprecatedGame.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecatedGame.swift; sourceTree = "<group>"; };
 		08CB6D7E1E672907003D96A9 /* QuizEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = QuizEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		08CB6D861E672907003D96A9 /* QuizEngine_iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QuizEngine_iOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F23AB6724D6222A001E3465 /* QuizDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizDataSource.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +129,7 @@
 				0868163D1E571F2F009359E4 /* Info.plist */,
 				086816551E572137009359E4 /* Flow.swift */,
 				087B1734218223B400EF41AB /* QuizDelegate.swift */,
+				8F23AB6724D6222A001E3465 /* QuizDataSource.swift */,
 				087B173F21822F8300EF41AB /* Quiz.swift */,
 				088F0BC71E69B7B80078C62D /* Question.swift */,
 				08CB6D521E6716B3003D96A9 /* DeprecatedGame.swift */,
@@ -337,6 +340,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				088F0BC81E69B7B80078C62D /* Question.swift in Sources */,
+				8F23AB6824D6222A001E3465 /* QuizDataSource.swift in Sources */,
 				087B174021822F8300EF41AB /* Quiz.swift in Sources */,
 				086816561E572137009359E4 /* Flow.swift in Sources */,
 				08CB6D531E6716B3003D96A9 /* DeprecatedGame.swift in Sources */,

--- a/Engine/QuizEngine.xcodeproj/project.pbxproj
+++ b/Engine/QuizEngine.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		08CB6D9B1E67296A003D96A9 /* Flow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086816551E572137009359E4 /* Flow.swift */; };
 		08CB6D9E1E67296A003D96A9 /* DeprecatedGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB6D521E6716B3003D96A9 /* DeprecatedGame.swift */; };
 		8F23AB6824D6222A001E3465 /* QuizDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F23AB6724D6222A001E3465 /* QuizDataSource.swift */; };
+		8FD55D4924D62669001C29E5 /* QuizDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F23AB6724D6222A001E3465 /* QuizDataSource.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -365,6 +366,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				088F0BC91E69B7B80078C62D /* Question.swift in Sources */,
+				8FD55D4924D62669001C29E5 /* QuizDataSource.swift in Sources */,
 				087B174121822F8300EF41AB /* Quiz.swift in Sources */,
 				08CB6D9B1E67296A003D96A9 /* Flow.swift in Sources */,
 				08CB6D9E1E67296A003D96A9 /* DeprecatedGame.swift in Sources */,
@@ -518,9 +520,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -540,9 +543,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/Engine/QuizEngine/DeprecatedGame.swift
+++ b/Engine/QuizEngine/DeprecatedGame.swift
@@ -30,23 +30,20 @@ public class Game <Question, Answer, R: Router> {
 
 @available(*, deprecated, message: "use Quiz.start instead")
 public func startGame<Question, Answer: Equatable, R: Router>(questions: [Question], router: R, correctAnswers: [Question: Answer]) -> Game<Question, Answer, R> where R.Question == Question, R.Answer == Answer {
-	let adapter = QuizDelegateToRouterAdapter(router, correctAnswers)
-    let quiz = Quiz.start(questions: questions, delegate: adapter, dataSource: adapter)
+	let delegateAdapter = QuizDelegateToRouterAdapter(router, correctAnswers)
+    let dataSourceAdapter = QuizDataSourceToRouterAdapter(router)
+    let quiz = Quiz.start(questions: questions, delegate: delegateAdapter, dataSource: dataSourceAdapter)
     return Game(quiz: quiz)
 }
 
 @available(*, deprecated, message: "remove along with the deprecated Game types")
-private class QuizDelegateToRouterAdapter<R: Router>: QuizDelegate & QuizDataSource where R.Answer: Equatable {
+private class QuizDelegateToRouterAdapter<R: Router>: QuizDelegate where R.Answer: Equatable {
 	private let router: R
 	private let correctAnswers: [R.Question: R.Answer]
 	
 	init(_ router: R, _ correctAnswers: [R.Question: R.Answer]) {
 		self.router = router
 		self.correctAnswers = correctAnswers
-	}
-	
-	func answer(for question: R.Question, completion: @escaping (R.Answer) -> Void) {
-		router.routeTo(question: question, answerCallback: completion)
 	}
 	
 	func didCompleteQuiz(withAnswers answers: [(question: R.Question, answer: R.Answer)]) {
@@ -65,4 +62,17 @@ private class QuizDelegateToRouterAdapter<R: Router>: QuizDelegate & QuizDataSou
 			return score + (correctAnswers[tuple.key] == tuple.value ? 1 : 0)
 		}
 	}
+}
+
+@available(*, deprecated, message: "remove along with the deprecated Game types")
+private class QuizDataSourceToRouterAdapter<R: Router>: QuizDataSource where R.Answer: Equatable {
+    private let router: R
+
+    init(_ router: R) {
+        self.router = router
+    }
+
+    func answer(for question: R.Question, completion: @escaping (R.Answer) -> Void) {
+        router.routeTo(question: question, answerCallback: completion)
+    }
 }

--- a/Engine/QuizEngine/DeprecatedGame.swift
+++ b/Engine/QuizEngine/DeprecatedGame.swift
@@ -31,12 +31,12 @@ public class Game <Question, Answer, R: Router> {
 @available(*, deprecated, message: "use Quiz.start instead")
 public func startGame<Question, Answer: Equatable, R: Router>(questions: [Question], router: R, correctAnswers: [Question: Answer]) -> Game<Question, Answer, R> where R.Question == Question, R.Answer == Answer {
 	let adapter = QuizDelegateToRouterAdapter(router, correctAnswers)
-	let quiz = Quiz.start(questions: questions, delegate: adapter)
+    let quiz = Quiz.start(questions: questions, delegate: adapter, dataSource: adapter)
     return Game(quiz: quiz)
 }
 
 @available(*, deprecated, message: "remove along with the deprecated Game types")
-private class QuizDelegateToRouterAdapter<R: Router>: QuizDelegate where R.Answer: Equatable {
+private class QuizDelegateToRouterAdapter<R: Router>: QuizDelegate & QuizDataSource where R.Answer: Equatable {
 	private let router: R
 	private let correctAnswers: [R.Question: R.Answer]
 	

--- a/Engine/QuizEngine/Flow.swift
+++ b/Engine/QuizEngine/Flow.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-final class Flow<Delegate: QuizDelegate, DataSource: QuizDataSource> {
+final class Flow<Delegate: QuizDelegate, DataSource: QuizDataSource> where Delegate.Question == DataSource.Question, Delegate.Answer == DataSource.Answer  {
     typealias Question = Delegate.Question
     typealias Answer = Delegate.Answer
     
@@ -26,7 +26,7 @@ final class Flow<Delegate: QuizDelegate, DataSource: QuizDataSource> {
     private func delegateQuestionHandling(at index: Int) {
         if index < questions.endIndex {
             let question = questions[index]
-            dataSource.answer(for: question as! DataSource.Question,
+            dataSource.answer(for: question,
                               completion: answer(for: question, at: index))
         } else {
 			delegate.didCompleteQuiz(withAnswers: answers)
@@ -39,8 +39,7 @@ final class Flow<Delegate: QuizDelegate, DataSource: QuizDataSource> {
     
     private func answer(for question: Question, at index: Int) -> (DataSource.Answer) -> Void {
         return { [weak self] answer in
-            let delegateAnswer = answer as! Delegate.Answer
-			self?.answers.replaceOrInsert((question, delegateAnswer), at: index)
+			self?.answers.replaceOrInsert((question, answer), at: index)
             self?.delegateQuestionHandling(after: index)
         }
     }

--- a/Engine/QuizEngine/Flow.swift
+++ b/Engine/QuizEngine/Flow.swift
@@ -26,8 +26,8 @@ final class Flow<Delegate: QuizDelegate, DataSource: QuizDataSource> {
     private func delegateQuestionHandling(at index: Int) {
         if index < questions.endIndex {
             let question = questions[index]
-            let answerCompletion = answer(for: question, at: index)
-            dataSource.answer(for: question as! DataSource.Question, completion: answerCompletion)
+            dataSource.answer(for: question as! DataSource.Question,
+                              completion: answer(for: question, at: index))
         } else {
 			delegate.didCompleteQuiz(withAnswers: answers)
         }

--- a/Engine/QuizEngine/Quiz.swift
+++ b/Engine/QuizEngine/Quiz.swift
@@ -11,11 +11,12 @@ public final class Quiz {
 		self.flow = flow
 	}
 	
-	public static func start<Delegate: QuizDelegate>(
+    public static func start<Delegate: QuizDelegate, DataSource: QuizDataSource>(
 		questions: [Delegate.Question],
-		delegate: Delegate
+		delegate: Delegate,
+        dataSource: DataSource
 	) -> Quiz where Delegate.Answer: Equatable {
-		let flow = Flow(questions: questions, delegate: delegate)
+		let flow = Flow(questions: questions, delegate: delegate, dataSource: dataSource)
 		flow.start()
 		return Quiz(flow: flow)
 	}

--- a/Engine/QuizEngine/Quiz.swift
+++ b/Engine/QuizEngine/Quiz.swift
@@ -15,7 +15,7 @@ public final class Quiz {
 		questions: [Delegate.Question],
 		delegate: Delegate,
         dataSource: DataSource
-	) -> Quiz where Delegate.Answer: Equatable {
+	) -> Quiz where Delegate.Answer: Equatable, Delegate.Question == DataSource.Question, Delegate.Answer == DataSource.Answer {
 		let flow = Flow(questions: questions, delegate: delegate, dataSource: dataSource)
 		flow.start()
 		return Quiz(flow: flow)

--- a/Engine/QuizEngine/QuizDataSource.swift
+++ b/Engine/QuizEngine/QuizDataSource.swift
@@ -1,0 +1,16 @@
+//
+//  QuizDataSource.swift
+//  QuizEngine
+//
+//  Created by Vinicius Moreira Leal on 02/08/2020.
+//  Copyright © 2020 Essential Developer. All rights reserved.
+//
+
+import Foundation
+
+public protocol QuizDataSource {
+    associatedtype Question
+    associatedtype Answer
+
+    func answer(for question: Question, completion: @escaping (Answer) -> Void)
+}

--- a/Engine/QuizEngine/QuizDelegate.swift
+++ b/Engine/QuizEngine/QuizDelegate.swift
@@ -4,13 +4,6 @@
 
 import Foundation
 
-public protocol QuizDataSource {
-    associatedtype Question
-    associatedtype Answer
-
-	func answer(for question: Question, completion: @escaping (Answer) -> Void)
-}
-
 public protocol QuizDelegate {
     associatedtype Question
     associatedtype Answer

--- a/Engine/QuizEngine/QuizDelegate.swift
+++ b/Engine/QuizEngine/QuizDelegate.swift
@@ -4,11 +4,16 @@
 
 import Foundation
 
-public protocol QuizDelegate {
-	associatedtype Question
-	associatedtype Answer
-	
+public protocol QuizDataSource {
+    associatedtype Question
+    associatedtype Answer
+
 	func answer(for question: Question, completion: @escaping (Answer) -> Void)
-	
-	func didCompleteQuiz(withAnswers: [(question: Question, answer: Answer)])
+}
+
+public protocol QuizDelegate {
+    associatedtype Question
+    associatedtype Answer
+
+    func didCompleteQuiz(withAnswers: [(question: Question, answer: Answer)])
 }

--- a/Engine/QuizEngineTests/FlowTest.swift
+++ b/Engine/QuizEngineTests/FlowTest.swift
@@ -112,7 +112,7 @@ class FlowTest: XCTestCase {
 	
 	private let delegate = DelegateSpy()
 	
-	private weak var weakSUT: Flow<DelegateSpy>?
+	private weak var weakSUT: Flow<DelegateSpy, DelegateSpy>?
 	
 	override func tearDown() {
 		super.tearDown()
@@ -120,8 +120,8 @@ class FlowTest: XCTestCase {
 		XCTAssertNil(weakSUT, "Memory leak detected. Weak reference to the SUT instance is not nil.")
 	}
 	
-    private func makeSUT(questions: [String]) -> Flow<DelegateSpy> {
-        let sut = Flow(questions: questions, delegate: delegate)
+    private func makeSUT(questions: [String]) -> Flow<DelegateSpy, DelegateSpy> {
+        let sut = Flow(questions: questions, delegate: delegate, dataSource: delegate)
 		weakSUT = sut
 		return sut
     }

--- a/Engine/QuizEngineTests/FlowTest.swift
+++ b/Engine/QuizEngineTests/FlowTest.swift
@@ -11,25 +11,25 @@ class FlowTest: XCTestCase {
     func test_start_withNoQuestions_doesNotDelegateQuestionHandling() {
         makeSUT(questions: []).start()
         
-        XCTAssertTrue(delegate.questionsAsked.isEmpty)
+        XCTAssertTrue(dataSource.questionsAsked.isEmpty)
     }
     
     func test_start_withOneQuestion_delegatesCorrectQuestionHandling() {
         makeSUT(questions: ["Q1"]).start()
         
-        XCTAssertEqual(delegate.questionsAsked, ["Q1"])
+        XCTAssertEqual(dataSource.questionsAsked, ["Q1"])
     }
 
     func test_start_withOneQuestion_delegatesAnotherCorrectQuestionHandling() {
         makeSUT(questions: ["Q2"]).start()
         
-        XCTAssertEqual(delegate.questionsAsked, ["Q2"])
+        XCTAssertEqual(dataSource.questionsAsked, ["Q2"])
     }
     
     func test_start_withTwoQuestions_delegatesFirstQuestionHandling() {
         makeSUT(questions: ["Q1", "Q2"]).start()
         
-        XCTAssertEqual(delegate.questionsAsked, ["Q1"])
+        XCTAssertEqual(dataSource.questionsAsked, ["Q1"])
     }
 
     func test_startTwice_withTwoQuestions_delegatesFirstQuestionHandlingTwice() {
@@ -38,26 +38,26 @@ class FlowTest: XCTestCase {
         sut.start()
         sut.start()
         
-        XCTAssertEqual(delegate.questionsAsked, ["Q1", "Q1"])
+        XCTAssertEqual(dataSource.questionsAsked, ["Q1", "Q1"])
     }
 
     func test_startAndAnswerFirstAndSecondQuestion_withThreeQuestions_delegatesSecondAndThirdQuestionHandling() {
         let sut = makeSUT(questions: ["Q1", "Q2", "Q3"])
         sut.start()
         
-        delegate.answerCompletions[0]("A1")
-        delegate.answerCompletions[1]("A2")
+        dataSource.answerCompletions[0]("A1")
+        dataSource.answerCompletions[1]("A2")
 
-        XCTAssertEqual(delegate.questionsAsked, ["Q1", "Q2", "Q3"])
+        XCTAssertEqual(dataSource.questionsAsked, ["Q1", "Q2", "Q3"])
     }
 
     func test_startAndAnswerFirstQuestion_withOneQuestion_doesNotDelegateAnotherQuestionHandling() {
         let sut = makeSUT(questions: ["Q1"])
         sut.start()
         
-        delegate.answerCompletions[0]("A1")
+        dataSource.answerCompletions[0]("A1")
         
-        XCTAssertEqual(delegate.questionsAsked, ["Q1"])
+        XCTAssertEqual(dataSource.questionsAsked, ["Q1"])
     }
 	
 	func test_start_withOneQuestion_doesNotCompleteQuiz() {
@@ -77,7 +77,7 @@ class FlowTest: XCTestCase {
         let sut = makeSUT(questions: ["Q1", "Q2"])
         sut.start()
         
-        delegate.answerCompletions[0]("A1")
+        dataSource.answerCompletions[0]("A1")
         
 		XCTAssertTrue(delegate.completedQuizzes.isEmpty)
     }
@@ -86,8 +86,8 @@ class FlowTest: XCTestCase {
         let sut = makeSUT(questions: ["Q1", "Q2"])
         sut.start()
         
-        delegate.answerCompletions[0]("A1")
-        delegate.answerCompletions[1]("A2")
+        dataSource.answerCompletions[0]("A1")
+        dataSource.answerCompletions[1]("A2")
 		
 		XCTAssertEqual(delegate.completedQuizzes.count, 1)
         assertEqual(delegate.completedQuizzes[0], [("Q1", "A1"), ("Q2", "A2")])
@@ -97,11 +97,11 @@ class FlowTest: XCTestCase {
 		let sut = makeSUT(questions: ["Q1", "Q2"])
 		sut.start()
 
-		delegate.answerCompletions[0]("A1")
-		delegate.answerCompletions[1]("A2")
+		dataSource.answerCompletions[0]("A1")
+		dataSource.answerCompletions[1]("A2")
 
-		delegate.answerCompletions[0]("A1-1")
-		delegate.answerCompletions[1]("A2-2")
+		dataSource.answerCompletions[0]("A1-1")
+		dataSource.answerCompletions[1]("A2-2")
 		
 		XCTAssertEqual(delegate.completedQuizzes.count, 2)
 		assertEqual(delegate.completedQuizzes[0], [("Q1", "A1"), ("Q2", "A2")])
@@ -111,8 +111,9 @@ class FlowTest: XCTestCase {
     // MARK: Helpers
 	
 	private let delegate = DelegateSpy()
+    private let dataSource = DataSourceSpy()
 	
-	private weak var weakSUT: Flow<DelegateSpy, DelegateSpy>?
+	private weak var weakSUT: Flow<DelegateSpy, DataSourceSpy>?
 	
 	override func tearDown() {
 		super.tearDown()
@@ -120,8 +121,8 @@ class FlowTest: XCTestCase {
 		XCTAssertNil(weakSUT, "Memory leak detected. Weak reference to the SUT instance is not nil.")
 	}
 	
-    private func makeSUT(questions: [String]) -> Flow<DelegateSpy, DelegateSpy> {
-        let sut = Flow(questions: questions, delegate: delegate, dataSource: delegate)
+    private func makeSUT(questions: [String]) -> Flow<DelegateSpy, DataSourceSpy> {
+        let sut = Flow(questions: questions, delegate: delegate, dataSource: dataSource)
 		weakSUT = sut
 		return sut
     }

--- a/Engine/QuizEngineTests/Helpers/DelegateSpy.swift
+++ b/Engine/QuizEngineTests/Helpers/DelegateSpy.swift
@@ -5,7 +5,7 @@
 import Foundation
 import QuizEngine
 
-class DelegateSpy: QuizDelegate {
+class DelegateSpy: QuizDelegate, QuizDataSource {
 	var questionsAsked: [String] = []
 	var answerCompletions: [(String) -> Void] = []
 	

--- a/Engine/QuizEngineTests/Helpers/DelegateSpy.swift
+++ b/Engine/QuizEngineTests/Helpers/DelegateSpy.swift
@@ -5,18 +5,20 @@
 import Foundation
 import QuizEngine
 
-class DelegateSpy: QuizDelegate, QuizDataSource {
-	var questionsAsked: [String] = []
-	var answerCompletions: [(String) -> Void] = []
-	
+class DelegateSpy: QuizDelegate {
 	var completedQuizzes: [[(String, String)]] = []
-	
-	func answer(for question: String, completion: @escaping (String) -> Void) {
-		questionsAsked.append(question)
-		answerCompletions.append(completion)
-	}
 	
 	func didCompleteQuiz(withAnswers answers: [(question: String, answer: String)]) {
 		completedQuizzes.append(answers)
 	}
+}
+
+class DataSourceSpy: QuizDataSource {
+    var questionsAsked: [String] = []
+    var answerCompletions: [(String) -> Void] = []
+
+    func answer(for question: String, completion: @escaping (String) -> Void) {
+        questionsAsked.append(question)
+        answerCompletions.append(completion)
+    }
 }

--- a/Engine/QuizEngineTests/QuizTest.swift
+++ b/Engine/QuizEngineTests/QuizTest.swift
@@ -11,8 +11,7 @@ class QuizTest: XCTestCase {
 	private var quiz: Quiz?
 	
 	func test_startQuiz_answersAllQuestions_completesWithAnswers() {
-		let delegate = DelegateSpy()
-        let dataSource = DataSourceSpy()
+		let (delegate, dataSource) = makeSpy()
 
         quiz = Quiz.start(questions: ["Q1", "Q2"], delegate: delegate, dataSource: dataSource)
 
@@ -24,8 +23,7 @@ class QuizTest: XCTestCase {
 	}
 	
 	func test_startQuiz_answersAllQuestionsTwice_completesWithNewAnswers() {
-		let delegate = DelegateSpy()
-        let dataSource = DataSourceSpy()
+		let (delegate, dataSource) = makeSpy()
 
         quiz = Quiz.start(questions: ["Q1", "Q2"], delegate: delegate, dataSource: dataSource)
 
@@ -39,5 +37,10 @@ class QuizTest: XCTestCase {
 		assertEqual(delegate.completedQuizzes[0], [("Q1", "A1"), ("Q2", "A2")])
 		assertEqual(delegate.completedQuizzes[1], [("Q1", "A1-1"), ("Q2", "A2-2")])
 	}
-	
+
+    // MARK: Helpers
+
+    private func makeSpy() -> (delegate: DelegateSpy, dataSource: DataSourceSpy) {
+        (DelegateSpy(), DataSourceSpy())
+    }
 }

--- a/Engine/QuizEngineTests/QuizTest.swift
+++ b/Engine/QuizEngineTests/QuizTest.swift
@@ -13,7 +13,7 @@ class QuizTest: XCTestCase {
 	func test_startQuiz_answersAllQuestions_completesWithAnswers() {
 		let delegate = DelegateSpy()
 
-		quiz = Quiz.start(questions: ["Q1", "Q2"], delegate: delegate)
+        quiz = Quiz.start(questions: ["Q1", "Q2"], delegate: delegate, dataSource: delegate)
 
 		delegate.answerCompletions[0]("A1")
 		delegate.answerCompletions[1]("A2")
@@ -25,7 +25,7 @@ class QuizTest: XCTestCase {
 	func test_startQuiz_answersAllQuestionsTwice_completesWithNewAnswers() {
 		let delegate = DelegateSpy()
 
-		quiz = Quiz.start(questions: ["Q1", "Q2"], delegate: delegate)
+        quiz = Quiz.start(questions: ["Q1", "Q2"], delegate: delegate, dataSource: delegate)
 
 		delegate.answerCompletions[0]("A1")
 		delegate.answerCompletions[1]("A2")

--- a/Engine/QuizEngineTests/QuizTest.swift
+++ b/Engine/QuizEngineTests/QuizTest.swift
@@ -12,11 +12,12 @@ class QuizTest: XCTestCase {
 	
 	func test_startQuiz_answersAllQuestions_completesWithAnswers() {
 		let delegate = DelegateSpy()
+        let dataSource = DataSourceSpy()
 
-        quiz = Quiz.start(questions: ["Q1", "Q2"], delegate: delegate, dataSource: delegate)
+        quiz = Quiz.start(questions: ["Q1", "Q2"], delegate: delegate, dataSource: dataSource)
 
-		delegate.answerCompletions[0]("A1")
-		delegate.answerCompletions[1]("A2")
+		dataSource.answerCompletions[0]("A1")
+		dataSource.answerCompletions[1]("A2")
 		
 		XCTAssertEqual(delegate.completedQuizzes.count, 1)
 		assertEqual(delegate.completedQuizzes[0], [("Q1", "A1"), ("Q2", "A2")])
@@ -24,14 +25,15 @@ class QuizTest: XCTestCase {
 	
 	func test_startQuiz_answersAllQuestionsTwice_completesWithNewAnswers() {
 		let delegate = DelegateSpy()
+        let dataSource = DataSourceSpy()
 
-        quiz = Quiz.start(questions: ["Q1", "Q2"], delegate: delegate, dataSource: delegate)
+        quiz = Quiz.start(questions: ["Q1", "Q2"], delegate: delegate, dataSource: dataSource)
 
-		delegate.answerCompletions[0]("A1")
-		delegate.answerCompletions[1]("A2")
+		dataSource.answerCompletions[0]("A1")
+		dataSource.answerCompletions[1]("A2")
 
-		delegate.answerCompletions[0]("A1-1")
-		delegate.answerCompletions[1]("A2-2")
+		dataSource.answerCompletions[0]("A1-1")
+		dataSource.answerCompletions[1]("A2-2")
 
 		XCTAssertEqual(delegate.completedQuizzes.count, 2)
 		assertEqual(delegate.completedQuizzes[0], [("Q1", "A1"), ("Q2", "A2")])


### PR DESCRIPTION
Hi Caio and Mike,

As suggested during an episode of the second season, I separated the 'QuizDelegate' into Delegate and Data Source.
I couldn't visualise a better way to handle the generics besides force casting when needed, in the 'Flow'.

What do you guys think?